### PR TITLE
Support using a function as `start` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "redux-promise-listener",
-  "version": "1.1.0",
+  "name": "@colony/redux-promise-listener",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -8,7 +8,7 @@ export type SetPayload = (Action, any) => Action
 export type GetPayload = Action => ?any
 export type ActionMatcher = Action => boolean
 export type Config = {
-  start: string,
+  start: string | (({ payload?: any, meta?: any }) => Action),
   resolve: string | ActionMatcher,
   reject: string | ActionMatcher,
   setPayload?: SetPayload,

--- a/src/reduxPromiseListener.js
+++ b/src/reduxPromiseListener.js
@@ -66,12 +66,16 @@ export default function createListener(): PromiseListener {
           }
         }
         listeners[listenerId] = listener
-        dispatch(
-          (config.setPayload || defaultSetPayload)(
+        let action
+        if (typeof config.start === 'function') {
+          action = config.start({ payload, meta: { id } })
+        } else {
+          action = (config.setPayload || defaultSetPayload)(
             { type: config.start, meta: { id } },
             payload
           )
-        )
+        }
+        dispatch(action)
       })
 
     return { asyncFunction, unsubscribe }


### PR DESCRIPTION
This PR adds support for passing in a function as the start property allowing for more complex workflows (like using action creators directly in the async function). Note that this will effectively override the setPayload property (which we should probably just remove anywhere as it’s not really needed anymore). I’ll leave it in for now with a note of deprecation.